### PR TITLE
Correct link to full source for example

### DIFF
--- a/docs/src/PlotAxis.elm
+++ b/docs/src/PlotAxis.elm
@@ -11,7 +11,7 @@ plotExample =
     { title = "Multiple axis"
     , code = code
     , view = view
-    , id = "Axis"
+    , id = "PlotAxis"
     }
 
 


### PR DESCRIPTION
This `id` is used to form the URL to the full source for the example at https://github.com/terezka/elm-plot/blob/b592b9cc098064bd3f9f40103726e2b2a7f0e2a4/docs/src/Docs.elm#L141, so it must be the same as the module name for the correct URL to be formed.