### PR TITLE
Adjust fill for the appropriate minimum

### DIFF
--- a/src/Internal/Draw.elm
+++ b/src/Internal/Draw.elm
@@ -199,7 +199,7 @@ areaBegin : PlotSummary -> List Point -> List Command
 areaBegin plot points =
   case points of
     { x, y } :: rest ->
-      [ Move x (yClosestToZero plot), Line x y ]
+      [ Move x plot.y.min, Line x y ]
 
     _ ->
       []
@@ -209,15 +209,10 @@ areaEnd : PlotSummary -> List Point -> List Command
 areaEnd plot points =
   case List.head <| List.reverse <| points of
     Just { x, y } ->
-      [ Line x (yClosestToZero plot) ]
+      [ Line x plot.y.min ]
 
     Nothing ->
       []
-
-
-yClosestToZero : PlotSummary -> Float
-yClosestToZero { y } =
-  clamp y.min y.max 0
 
 
 -- PATH COMMANDS

--- a/src/Plot.elm
+++ b/src/Plot.elm
@@ -1133,7 +1133,7 @@ addNiceReachForArea area ({ y, x } as summary) =
         Just _ ->
             { summary
                 | x = x
-                , y = { y | min = min y.min 0, max = y.max }
+                , y = { y | min = closestToZero y.min y.max, max = y.max }
             }
 
 

--- a/src/Plot.elm
+++ b/src/Plot.elm
@@ -1133,7 +1133,7 @@ addNiceReachForArea area ({ y, x } as summary) =
         Just _ ->
             { summary
                 | x = x
-                , y = { y | min = closestToZero y.min y.max, max = y.max }
+                , y = { y | min = y.min, max = y.max }
             }
 
 


### PR DESCRIPTION
What?
=====

This updates `Plot.addNiceReachForArea` to recalculate the minimum `y`
using `closestToZero` instead of `min`ing against 0. This ensures that
the minimum isn't artificially low relative to the provided data.

Before:

![analysis__t01_-_2017-01-01](https://user-images.githubusercontent.com/1574/29318441-03a1ec06-819e-11e7-8f40-d3fb4e55b935.png)

After:

![analysis__t01_-_2017-01-01](https://user-images.githubusercontent.com/1574/29318476-2b9e8f2a-819e-11e7-977c-18d025f05772.png)

