### PR TITLE
Fix link to official Elm documentation

### DIFF
--- a/docs/src/Page/GettingStarted.elm
+++ b/docs/src/Page/GettingStarted.elm
@@ -118,7 +118,7 @@ view model =
             , E.text " or the "
             , E.link
                 [ F.underline ]
-                { url = "https://package.elm-lang.org/packages/terezka/charts/latest"
+                { url = "https://package.elm-lang.org/packages/terezka/elm-charts/latest"
                 , label = E.text "official Elm documentation"
                 }
             , E.text ". Install by running the following command in your project directory:"


### PR DESCRIPTION
Hi.

There are three links to "official Elm documentation" in the docs.
And one of them had the wrong destination (to elm-charts-alpha).