### PR TITLE
Make functions tail-call recursive

### DIFF
--- a/src/Internal/Helpers.elm
+++ b/src/Internal/Helpers.elm
@@ -33,7 +33,7 @@ gatherWith testFn list =
             [] -> List.reverse gathered
             toGather :: population ->
               let ( gathering, remaining ) = List.partition (testFn toGather) population in
-              helper remaining <| ( toGather, gathering ) :: gathered
+              helper remaining (( toGather, gathering ) :: gathered)
     in
     helper list []
 

--- a/src/Internal/Interpolation.elm
+++ b/src/Internal/Interpolation.elm
@@ -57,17 +57,17 @@ monotonePart points ( tangent, commands ) =
       let t1 = slope3 p0 p1 p2
           t0 = slope2 p0 p1 t1
       in
-      ( Previous t1
-      , commands ++ [ monotoneCurve p0 p1 t0 t1 ]
-      )
-      |> monotonePart (p1 :: p2 :: rest)
+      monotonePart (p1 :: p2 :: rest)
+        ( Previous t1
+        , commands ++ [ monotoneCurve p0 p1 t0 t1 ]
+        )
 
     ( Previous t0, p0 :: p1 :: p2 :: rest ) ->
       let t1 = slope3 p0 p1 p2 in
-      ( Previous t1
-      , commands ++ [ monotoneCurve p0 p1 t0 t1 ]
-      )
-      |> monotonePart (p1 :: p2 :: rest)
+      monotonePart (p1 :: p2 :: rest)
+        ( Previous t1
+        , commands ++ [ monotoneCurve p0 p1 t0 t1 ]
+        )
 
     ( First, [ p0, p1 ] ) ->
       let t1 = slope3 p0 p1 p1 in


### PR DESCRIPTION
2 changes here, both making some functions tail-call recursive.

For `monotonePart`, the `|>` prevented the optimization from happening.

For `gatherWith`, it's the same issue but because of `<|`. I made the same fix in `elm-community/list-extra` (https://github.com/elm-community/list-extra/commit/2d0eb640453313e8e1efc156a29ac68aecb21008#diff-97b2cb39788ae3d6877530635d216e6cd361006507af40173e5affcb5f095331)

I found this using using the [NoUnoptimizedRecursion](https://package.elm-lang.org/packages/jfmengels/elm-review-performance/latest/NoUnoptimizedRecursion] `elm-review` rule, which you can try out by running the following command:
```
elm-review --template jfmengels/elm-review-performance/example --rules NoUnoptimizedRecursion
```

There are some more to be fixed, but they're not as trivial, and the performance benefits will have to be evaluated.