### PR TITLE
Set chart rectangle to fill="none"

### DIFF
--- a/src/Internal/Svg.elm
+++ b/src/Internal/Svg.elm
@@ -94,7 +94,7 @@ container plane config below chartEls above =
         , SA.y (String.fromFloat plane.y.marginMin)
         , SA.width (String.fromFloat (Coord.innerWidth plane))
         , SA.height (String.fromFloat (Coord.innerHeight plane))
-        , SA.fill "transparent"
+        , SA.fill "none"
         ]
 
       clipPathDefs =


### PR DESCRIPTION
Hi @terezka  👋  I had some trouble getting SVG elements to receive pointer events on a chart. After digging into things, I realized that the `chartPosition` rectangle sets fill to transparent, which effectively blocks pointer events from being propagated to other elements in the chart. The short version of the fix is to use a `none` fill, rather than `transparent`, which allows other elements to handle pointer events. I don't think (?) there's a good reason for this rectangle to be transparent rather than none, since it appears to exist for layout reasons.

Here is [Ellie](https://ellie-app.com/fWpFpJJfM9pa1) with an example. After applying the change in this PR, the "no clicky" becomes clickable.

![Screen Shot 2021-11-24 at 12 55 43 PM](https://user-images.githubusercontent.com/888624/143313139-d39b7b06-d137-4a8e-a5e7-60c885cbe4a5.png)


More details: Even though it's possible to set SVG `pointer-events` attributes, and after trying a myriad of settings on the chart, I realized part of the trouble is that I can't modify this rectangles attributes and there isn't much I can do to allow pointer events to go through it (also, I _think_, that despite setting pointer-events of other SVG elements in the chart, it doesn't help, because they are not inserted as a child of this rectangle, this empty rectangle is added after all the other SVG elements, so no pointer events are propagated even if `pointer-events` attributes allow them to "pass through"). So I can't come up with any workaround, but let me know if you can think of one.