### PR TITLE
Fix the doc comment example for onMouseMove

### DIFF
--- a/src/Chart/Events.elm
+++ b/src/Chart/Events.elm
@@ -65,7 +65,7 @@ onDoubleClick onMsg decoder =
 {-| Add a mouse move event handler.
 
     C.chart
-      [ CE.onMouseMove (CE.getNearest CI.bars) ]
+      [ CE.onMouseMove OnHover (CE.getNearest CI.bars) ]
       [ .. ]
 
 See example at [elm-charts.org](https://www.elm-charts.org/documentation/interactivity/basic-bar-tooltip).


### PR DESCRIPTION
The website example has this right, but the function doc comment doesn't - one argument is missing. This should make it a little bit more correct 🙂 