### PR TITLE
update broken dependency

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -3,7 +3,7 @@
     "name": "terezka/elm-charts",
     "summary": "SVG charts components in Elm.",
     "license": "BSD-3-Clause",
-    "version": "3.0.0",
+    "version": "3.0.1",
     "exposed-modules": [
         "Chart.Attributes",
         "Chart.Events",

--- a/elm.json
+++ b/elm.json
@@ -19,7 +19,7 @@
         "elm/json": "1.0.0 <= v < 2.0.0",
         "elm/svg": "1.0.1 <= v < 2.0.0",
         "elm/time": "1.0.0 <= v < 2.0.0",
-        "ryannhg/date-format": "2.3.0 <= v < 3.0.0",
+        "ryan-haskell/date-format": "1.0.0 <= v < 2.0.0",
         "terezka/intervals": "2.0.1 <= v < 3.0.0"
     },
     "test-dependencies": {}


### PR DESCRIPTION
Hi there! The `ryannhg/date-format` has been renamed to `ryan-haskell/date-format` as noted [here](https://discourse.elm-lang.org/t/username-changed/9705)

This PR updates the dependency name to ensure the `elm-charts` package can be used, otherwise, we will see the following error:

```
-- CORRUPT PACKAGE DATA --------------------------------------------------------

I downloaded the source code for ryannhg/date-format 2.3.0 from:

    https://github.com/ryannhg/date-format/zipball/2.3.0/

But it looks like the hash of the archive has changed since publication:

  Expected: [7]()9bec685f43f23fea279556757f2
    Actual: 86534[14]()6f5a550bb8e87b87a7484ea5732090bb5

This usually means that the package author moved the version tag, so report it
to them and see if that is the issue. Folks on Elm slack can probably help as
well.
```